### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,8 @@ fixtures:
     augeasproviders_core: "git://github.com/simp/augeasproviders_core"
     augeasproviders_grub: "git://github.com/simp/augeasproviders_grub"
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     iptables: "git://github.com/simp/pupmod-simp-iptables"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -6,6 +6,7 @@ fixtures:
     augeasproviders_core: "#{source_dir}/../augeasproviders_core"
     augeasproviders_grub: "#{source_dir}/../augeasproviders_grub"
     common: "#{source_dir}/../common"
-    concat: "#{source_dir}/../concat"
+    simplib: "#{source_dir}/../simplib"
+    simpcat: "#{source_dir}/../simpcat"
     iptables: "#{source_dir}/../iptables"
     stdlib: "#{source_dir}/../stdlib"

--- a/build/pupmod-ntpd.spec
+++ b/build/pupmod-ntpd.spec
@@ -1,14 +1,14 @@
 Summary: NTP Puppet Module
 Name: pupmod-ntpd
 Version: 4.1.0
-Release: 8
+Release: 9
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-auditd >= 4.1.0-3
 Requires: pupmod-iptables >= 4.1.0-3
-Requires: pupmod-concat >= 4.0.0-0
+Requires: pupmod-simpcat >= 4.0.0-0
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
@@ -59,6 +59,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-9
+- migration to simplib and simpcat (lib/ only)
+
 * Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-8
 - Updated the default restrict options to be more restrictive.
 - Ref: https://access.redhat.com/articles/1305723


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-ntpd`.
SIMP-604 #comment Updated `pupmod-simp-ntpd`.