### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Tue Feb 23 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-10
 - Added compliance function support
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-simp-auditd >= 4.1.0-3
 Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-iptables >= 4.1.0-3
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-ntpd-test

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -18,7 +18,7 @@ define ntpd::allow (
 ) {
   $l_client_nets = nets2ddq($client_nets)
 
-  concat_fragment { "ntpd+${name}.allow":
+  simpcat_fragment { "ntpd+${name}.allow":
     content => template('ntpd/ntp.allow.erb')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,12 +89,12 @@ class ntpd (
     }
   }
 
-  concat_build { 'ntpd':
+  simpcat_build { 'ntpd':
     order  => ['ntp.conf', '*.allow'],
     target => '/etc/ntp.conf'
   }
 
-  concat_fragment { 'ntpd+ntp.conf':
+  simpcat_fragment { 'ntpd+ntp.conf':
     content => template('ntpd/ntp.conf.erb')
   }
 
@@ -137,7 +137,7 @@ SYNC_HWCLOCK=yes\n",
     owner     => 'root',
     group     => 'ntp',
     mode      => '0600',
-    subscribe => Concat_build['ntpd'],
+    subscribe => Simpcat_build['ntpd'],
     audit     => content,
     notify    => Service['ntpd']
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-ntpd",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "manages NTP server and client",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,14 +9,14 @@ describe 'ntpd' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_build('ntpd') }
-        it { is_expected.to create_concat_fragment('ntpd+ntp.conf').with_content(/fudge\s+127\.127\.1\.0\s+stratum 2/) }
+        it { is_expected.to create_simpcat_build('ntpd') }
+        it { is_expected.to create_simpcat_fragment('ntpd+ntp.conf').with_content(/fudge\s+127\.127\.1\.0\s+stratum 2/) }
 
         context 'virtual' do
           let(:facts){{ :virtual => 'kvm' }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('ntpd+ntp.conf').with_content(/tinker panic 0/) }
+          it { is_expected.to create_simpcat_fragment('ntpd+ntp.conf').with_content(/tinker panic 0/) }
         end
 
         context 'with_auditd' do
@@ -36,7 +36,7 @@ describe 'ntpd' do
           }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('ntpd+ntp.conf').with_content(/fudge\s+127\.127\.1\.0\s+stratum 10/) }
+          it { is_expected.to create_simpcat_fragment('ntpd+ntp.conf').with_content(/fudge\s+127\.127\.1\.0\s+stratum 10/) }
         end
       end
     end

--- a/spec/defines/allow_spec.rb
+++ b/spec/defines/allow_spec.rb
@@ -8,7 +8,7 @@ describe 'ntpd::allow' do
         let(:title){ 'test' }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment("ntpd+#{title}.allow").with_content(<<-EOF.gsub(/^\s+/,'')
+        it { is_expected.to create_simpcat_fragment("ntpd+#{title}.allow").with_content(<<-EOF.gsub(/^\s+/,'')
           restrict 1.2.3.0 mask 255.255.255.0
           restrict 3.4.5.6
           EOF


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'ntpd'
