### PR TITLE
(SIMP-4501) nptd: Manage step-tickers file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,10 +20,17 @@
       - '.vendor'
       - 'vendor'
 
-.setup_bundler_env: &setup_bundler_env
+.setup_env: &setup_env
   before_script:
     - '(find .vendor | wc -l) || :'
-    - bundle check || gem install bundler --no-rdoc --no-ri
+    - bundle || gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.setup_env_beaker: &setup_env_beaker
+  before_script:
+    - '(find .vendor | wc -l) || :'
     - rm -f Gemfile.lock
     - rm -rf pkg/
     - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
@@ -60,7 +67,7 @@ pup4.7-validation:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.7-unit:
@@ -71,7 +78,7 @@ pup4.7-unit:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -85,7 +92,7 @@ pup4.8-validation:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.8-unit:
@@ -96,7 +103,7 @@ pup4.8-unit:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -111,7 +118,7 @@ pup4.10-validation:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.10-unit:
@@ -122,7 +129,7 @@ pup4.10-unit:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -137,8 +144,9 @@ pup5.3-validation:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
+  allow_failure: true
 
 pup5.3-unit:
   stage: unit
@@ -148,7 +156,7 @@ pup5.3-unit:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
   allow_failure: true
 
@@ -163,7 +171,7 @@ pup5.latest-validation:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
   allow_failure: true
 
@@ -175,34 +183,33 @@ pup5.latest-unit:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
   allow_failure: true
 
 
 
-# No acceptance tests yet
 # Acceptance tests
 # ==============================================================================
-#acceptance-default:
-#  stage: acceptance
-#  tags:
-#    - beaker
-#  <<: *cache_bundler
-#  <<: *setup_bundler_env
-#  variables:
-#    PUPPET_VERSION: '4.10'
-#  script:
-#    - bundle exec rake beaker:suites[default]
-#
-#acceptance-fips-default:
-#  stage: acceptance
-#  tags:
-#    - beaker
-#  <<: *cache_bundler
-#  <<: *setup_bundler_env
-#  variables:
-#    PUPPET_VERSION: '4.10'
-#    BEAKER_fips: 'yes'
-#  script:
-#    - bundle exec rake beaker:suites[default]
+acceptance-default:
+  stage: acceptance
+  tags:
+   - beaker
+  <<: *cache_bundler
+  <<: *setup_env_beaker
+  variables:
+    PUPPET_VERSION: '4.10'
+  script:
+    - bundle exec rake beaker:suites[default]
+
+acceptance-fips-default:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_env_beaker
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,8 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check
---no-140chars-check
 --no-trailing_comma-check
-# This is here because the code can't handle lookups in parameters and we have
-# a LOT of those
---no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 * Thu Mar 08 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.0.4-0
 - Manage `/etc/ntp/step-tickers`
+- Manage `/etc/sysconfig/ntpdate`
+  - `SYNC_HWCLOCK=yes` is now set here instead of `/etc/sysconfig/ntp`
 - Add `$package_ensure` parameter to control the `ntp` package version
 - Move some multiline strings into variables (style recommendation)
 - The module now only requires one puppet run to apply completely

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,10 +10,10 @@
 - The module now only requires one puppet run to apply completely
 - Added essential-level acceptance test
 
-* Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+* Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - Update upperbound on puppetlabs/concat version to < 5.0.0
 
-* Wed Nov 22 2017 Steven Pritchard <steven.pritchard@onyxpoint.com> - 6.0.4-0
+* Wed Nov 22 2017 Steven Pritchard <steven.pritchard@onyxpoint.com> - 6.1.0-0
 - Documentation updates
 
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.3-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
-* Thu Mar 08 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.0.4-0
-- Manage `/etc/ntp/step-tickers`
-- Manage `/etc/sysconfig/ntpdate`
-  - `SYNC_HWCLOCK=yes` is now set here instead of `/etc/sysconfig/ntp`
+* Thu Mar 08 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
+- Manage ntpdate via `ntpd::ntpdate`
+  - Manage `/etc/ntp/step-tickers`
+  - Manage `/etc/sysconfig/ntpdate`
+    - New params ntpdate_sync_hwclock, ntpdate_retrym and ntpdate_options should
+      cover all options from RedHat
+    - `SYNC_HWCLOCK=yes` is now set here instead of `/etc/sysconfig/ntp`
 - Add `$package_ensure` parameter to control the `ntp` package version
 - Move some multiline strings into variables (style recommendation)
 - The module now only requires one puppet run to apply completely

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Thu Mar 08 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.0.4-0
+- Manage `/etc/ntp/step-tickers`
+- Add `$package_ensure` parameter to control the `ntp` package version
+- Move some multiline strings into variables (style recommendation)
+- The module now only requires one puppet run to apply completely
+- Added essential-level acceptance test
+
 * Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
 - Update upperbound on puppetlabs/concat version to < 5.0.0
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,9 +1,0 @@
-Obsoletes: pupmod-ntpd-test
-Requires: pupmod-puppetlabs-concat < 4.0.0-0
-Requires: pupmod-puppetlabs-concat >= 2.2.0-0
-Requires: pupmod-simp-auditd < 8.0.0-0
-Requires: pupmod-simp-auditd >= 7.0.0-0
-Requires: pupmod-simp-iptables < 7.0.0-0
-Requires: pupmod-simp-iptables >= 6.0.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,0 +1,3 @@
+---
+ntpd::ntpd_options: '-A -u ntp:ntp -p /var/run/ntpd.pid'
+ntpd::ntpdate_options: '-U ntp -s -b'

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,0 +1,3 @@
+---
+ntpd::ntpd_options: '-g'
+ntpd::ntpdate_options: '-p 2'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "OSFamily + Release"
+    backend: "yaml"
+    path: "os/%{facts.osfamily}-%{facts.operatingsystemmajrelease}"
+  - name: "Common"
+    backend: "yaml"
+    path: "common"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,16 +104,20 @@ class ntpd (
     notify => Service['ntpd']
   }
 
-  $_sysconfig_content = @(EOF)
-    OPTIONS="-A -u ntp:ntp -p /var/run/ntpd.pid"
-    SYNC_HWCLOCK=yes
-    | EOF
   file { '/etc/sysconfig/ntpd':
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0640',
-    content => $_sysconfig_content,
+    content => "OPTIONS=\"-A -u ntp:ntp -p /var/run/ntpd.pid\"\n",
+    notify  => Service['ntpd']
+  }
+  file { '/etc/sysconfig/ntpdate':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content => "SYNC_HWCLOCK=yes\n",
     notify  => Service['ntpd']
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,12 +33,6 @@
 #
 #   * Set to an empty array to disable
 #
-# @param auditd
-#   Enable auditd monitoring of the ntp configuration files
-#
-#   * This probably isn't needed in most cases since Puppet controls these
-#     files, but some systems require it
-#
 # @param disable_monitor
 #   Disable the monitoring facility to prevent amplification attacks using
 #   ``ntpdc monlist`` command when default restrict does not include the
@@ -46,10 +40,20 @@
 #
 #   * See CVE-2013-5211 for details
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @param manage_step_tickers Manage /etc/ntp/step-tickers
+#
+# @param auditd
+#   Enable auditd monitoring of the ntp configuration files
+#
+#   * This probably isn't needed in most cases since Puppet controls these
+#     files, but some systems require it
+#
+# @param package_ensure `ensure` parameter for the `ntp` package
+#
+# @author https://github.com/simp/pupmod-simp-ntpd/graphs/contributors
 #
 class ntpd (
-  Ntpd::Servers  $servers            = simplib::lookup('simp_options::ntpd::servers', { 'default_value' => {} }),
+  Ntpd::Servers $servers             = simplib::lookup('simp_options::ntpd::servers', { 'default_value' => {} }),
   Integer[0]    $stratum             = 2,
   Array[String] $logconfig           = ['=syncall','+clockall'],
   Numeric       $broadcastdelay      = 0.004,

--- a/manifests/ntpdate.pp
+++ b/manifests/ntpdate.pp
@@ -1,0 +1,36 @@
+# == Class: ntpd::ntpdate
+#
+class ntpd::ntpdate {
+  assert_private()
+
+  $bool_to_yes_no = {
+    true  => 'yes',
+    false => 'no'
+  }
+
+  $ntpdate_vars = {
+    'sync_hwclock' => $bool_to_yes_no[$::ntpd::ntpdate_sync_hwclock],
+    'retry'        => $::ntpd::ntpdate_retry,
+    'options'      => $::ntpd::ntpdate_options,
+  }
+  file { '/etc/sysconfig/ntpdate':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content => epp("${module_name}/ntpdate.epp", $ntpdate_vars)
+  }
+
+  $servers = $::ntpd::ntpdate_servers
+  if $servers =~ Array {
+    $_servers = $servers
+  }
+  else {
+    $_servers = $servers.keys
+  }
+  file { '/etc/ntp/step-tickers':
+    ensure  => 'file',
+    content => epp("${module_name}/step-tickers.epp", { 'ntp_servers' => $_servers }),
+    notify  => Service['ntpd']
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ntpd",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "manages NTP server and client",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_ntp_spec.rb
+++ b/spec/acceptance/suites/default/00_ntp_spec.rb
@@ -26,6 +26,37 @@ describe 'prepare system for kubeadm' do
       it 'should be idempotent' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
+
+      describe file('/etc/ntp.conf') do
+        ntp_conf = File.read('spec/acceptance/suites/default/expected/ntp.conf.txt')
+
+        it { should be_file }
+        its(:content) { should match(ntp_conf) }
+      end
+
+      describe file('/etc/ntp/step-tickers') do
+        step_tickers = <<-EOF.gsub(/^\s+/,'')
+          # List of NTP servers used by the ntpdate service.
+          # This file is managed by Puppet (module: ntp)
+          0.rhel.pool.ntp.org
+          1.rhel.pool.ntp.org
+          2.rhel.pool.ntp.org
+          3.rhel.pool.ntp.org
+        EOF
+
+        it { should be_file }
+        its(:content) { should match(step_tickers) }
+      end
+
+      describe file('/etc/sysconfig/ntpd') do
+        it { should be_file }
+        its(:content) { should match(%r{OPTIONS="-A -u ntp:ntp -p /var/run/ntpd.pid"}) }
+      end
+
+      describe file('/etc/sysconfig/ntpdate') do
+        it { should be_file }
+        its(:content) { should match(/SYNC_HWCLOCK=yes/) }
+      end
     end
   end
 end

--- a/spec/acceptance/suites/default/00_ntp_spec.rb
+++ b/spec/acceptance/suites/default/00_ntp_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper_acceptance'
+require 'json'
+
+test_name 'prepare system for kubeadm'
+
+describe 'prepare system for kubeadm' do
+  let(:hiera) {{
+    'simp_options::ntpd::servers' => [
+      '0.rhel.pool.ntp.org',
+      '1.rhel.pool.ntp.org',
+      '2.rhel.pool.ntp.org',
+      '3.rhel.pool.ntp.org',
+    ]
+  }}
+  let(:manifest) {
+    "include 'ntpd'"
+  }
+
+  context 'on each host' do
+    hosts.each do |host|
+      it 'should work with default values' do
+        set_hieradata_on(host, hiera)
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/expected/ntp.conf.txt
+++ b/spec/acceptance/suites/default/expected/ntp.conf.txt
@@ -1,0 +1,22 @@
+# This file is managed by Puppet. DO NOT EDIT.
+logconfig =syncall +clockall
+
+tinker panic 0
+
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+
+restrict 127.0.0.1
+restrict -6 ::1
+
+server  127.127.1.0 # local clock
+fudge 127.127.1.0 stratum 10
+
+
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 3.rhel.pool.ntp.org
+driftfile /var/lib/ntp/drift
+broadcastdelay  0.004
+disable monitor

--- a/spec/acceptance/suites/default/metadata.yml
+++ b/spec/acceptance/suites/default/metadata.yml
@@ -1,0 +1,2 @@
+---
+'default_run' : true

--- a/spec/acceptance/suites/default/nodesets/default.yml
+++ b/spec/acceptance/suites/default/nodesets/default.yml
@@ -1,0 +1,22 @@
+HOSTS:
+  centos7:
+    roles:
+      - server
+      - default
+      - master
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+  centos6:
+    roles:
+      - el6
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type:      aio
+  synced_folder: disabled
+  vagrant_memsize: 256
+# vb_gui: true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,6 +14,9 @@ describe 'ntpd' do
         it { is_expected.to_not contain_class('auditd')}
         it { is_expected.to create_file('/etc/sysconfig/ntpd').with_content(<<-EOF.gsub(/^\s+/,'')
             OPTIONS="-A -u ntp:ntp -p /var/run/ntpd.pid"
+          EOF
+        ) }
+        it { is_expected.to create_file('/etc/sysconfig/ntpdate').with_content(<<-EOF.gsub(/^\s+/,'')
             SYNC_HWCLOCK=yes
           EOF
         ) }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,46 +1,79 @@
 require 'spec_helper'
 
 describe 'ntpd' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) do
-          facts
-        end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
 
-        context 'with default parmeters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat('/etc/ntp.conf') }
-          it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/fudge\s+127\.127\.1\.0\s+stratum 2/) }
-          it { is_expected.to_not contain_class('auditd')}
-        end
+      context 'with default parmeters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat('/etc/ntp.conf') }
+        it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/fudge\s+127\.127\.1\.0\s+stratum 2/) }
+        it { is_expected.to_not contain_class('auditd')}
+        it { is_expected.to create_file('/etc/sysconfig/ntpd').with_content(<<-EOF.gsub(/^\s+/,'')
+            OPTIONS="-A -u ntp:ntp -p /var/run/ntpd.pid"
+            SYNC_HWCLOCK=yes
+          EOF
+        ) }
+      end
 
-        context 'virtual' do
-          let(:facts){{ :virtual => 'kvm' }}
+      context 'virtual' do
+        let(:facts){{ :virtual => 'kvm' }}
 
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/tinker panic 0/) }
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/tinker panic 0/) }
+      end
 
-        context 'with auditd => true' do
-          let(:params){{ :auditd => true }}
+      context 'with auditd => true' do
+        let(:params){{ :auditd => true }}
 
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('auditd') }
-          it { is_expected.to create_auditd__rule('ntp') }
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('auditd') }
+        it { is_expected.to create_auditd__rule('ntp').with_content(<<-EOF.gsub(/^\s+/,'')
+            -w /etc/ntp.conf -p wa -k CFG_ntp
+            -w /etc/ntp/keys -p wa -k CFG_ntp
+          EOF
+        ) }
+      end
 
-        context 'with_servers_hash' do
-          let(:params){{
-            'servers' => {
-              'time.bar.baz' => ['prefer'],
-              'time.other.net' => []
-            }
-          }}
+      context 'with servers array' do
+        let(:params){{
+          'servers' => [
+            'time.bar.baz',
+            'time.other.net'
+          ]
+        }}
 
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/fudge\s+127\.127\.1\.0\s+stratum 10/) }
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/fudge\s+127\.127\.1\.0\s+stratum 10/) }
+        it { is_expected.to create_file('/etc/ntp/step-tickers').with_content(<<-EOF.gsub(/^\s+/,'')
+            # List of NTP servers used by the ntpdate service.
+            # This file is managed by Puppet (module: ntp)
+            time.bar.baz
+            time.other.net
+          EOF
+        ) }
+      end
+
+      context 'with servers hash' do
+        let(:params){{
+          'servers' => {
+            'time.bar.baz' => ['prefer'],
+            'time.other.net' => []
+          }
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat__fragment('main_ntp_configuration').with_content(/fudge\s+127\.127\.1\.0\s+stratum 10/) }
+        it { is_expected.to create_file('/etc/ntp/step-tickers').with_content(<<-EOF.gsub(/^\s+/,'')
+            # List of NTP servers used by the ntpdate service.
+            # This file is managed by Puppet (module: ntp)
+            time.bar.baz
+            time.other.net
+          EOF
+        ) }
       end
     end
   end

--- a/templates/ntpdate.epp
+++ b/templates/ntpdate.epp
@@ -1,0 +1,15 @@
+<% |
+  Enum['yes','no'] $sync_hwclock,
+  Integer $retry,
+  String $options,
+| -%>
+# Configuration for the ntpdate script that runs at boot
+# This file is managed by Puppet (module: ntp)
+<% if $options { -%>
+# Options for ntpdate
+OPTIONS="<%= $options %>"
+<% } -%>
+# Number of retries before giving up
+RETRY=<%= $retry %>
+# Set to 'yes' to sync hw clock after successful ntpdate
+SYNC_HWCLOCK=<%= $sync_hwclock %>

--- a/templates/step-tickers.epp
+++ b/templates/step-tickers.epp
@@ -1,0 +1,6 @@
+<% | Array $ntp_servers | -%>
+# List of NTP servers used by the ntpdate service.
+# This file is managed by Puppet (module: ntp)
+<% $ntp_servers.each |$server| { -%>
+<%= $server %>
+<% } -%>

--- a/types/servers.pp
+++ b/types/servers.pp
@@ -1,0 +1,7 @@
+# ntp servers can be an array of servers
+#   or
+# a hash where the keys are servers and the values are an array of options
+type Ntpd::Servers = Variant[
+  Array[String],
+  Hash[String, Array[String]]
+]


### PR DESCRIPTION
This commit adds optional management of the `/etc/ntp/step-tickers`
file. It uses `simp_options::ntp::servers` value to populate it.

- Manage `/etc/ntp/step-tickers`
- Manage `/etc/sysconfig/ntpdate`
  - `SYNC_HWCLOCK=yes` is now set here instead of `/etc/sysconfig/ntp`
- Add `$package_ensure` parameter to control the `ntp` package version
- Move some multiline strings into variables (style recommendation)
- The module now only requires one puppet run to apply completely
- Added essential-level acceptance test

SIMP-4501 #close
SIMP-4503 #close