### PR TITLE
(SIMP-4943) ntpd_options not always applied

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Fri Jul 13 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2-0
+* Mon Aug 27 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
+- Fixed bug in which ntpd::ntpd_options was not applied to ntpd::servers
+  when ntpd::servers is an array.
+
+* Fri Jul 13 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1-0
 - Add support for Puppet 5 and OEL
 
 * Fri Jun 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ntpd",
-  "version": "6.1.2",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "manages NTP server and client",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/expected/ntp.conf.txt
+++ b/spec/acceptance/suites/default/expected/ntp.conf.txt
@@ -12,11 +12,10 @@ restrict -6 ::1
 server  127.127.1.0 # local clock
 fudge 127.127.1.0 stratum 10
 
-
-server 0.rhel.pool.ntp.org
-server 1.rhel.pool.ntp.org
-server 2.rhel.pool.ntp.org
-server 3.rhel.pool.ntp.org
+server 0.rhel.pool.ntp.org minpoll 4 maxpoll 4 iburst
+server 1.rhel.pool.ntp.org minpoll 4 maxpoll 4 iburst
+server 2.rhel.pool.ntp.org minpoll 4 maxpoll 4 iburst
+server 3.rhel.pool.ntp.org minpoll 4 maxpoll 4 iburst
 driftfile /var/lib/ntp/drift
 broadcastdelay  0.004
 disable monitor

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -1,5 +1,7 @@
+<% unless @logconfig.empty? -%>
 logconfig <%= @logconfig.join(' ') %>
 
+<% end -%>
 <% if !@virtual.eql?('physical') -%>
 tinker panic 0
 
@@ -13,15 +15,17 @@ restrict -6 ::1
 <% if @servers.empty? -%>
 server  127.127.1.0 # local clock
 fudge 127.127.1.0 stratum <%= @stratum %>
+
 <% elsif !@virtual.eql?('vmware') -%>
 server  127.127.1.0 # local clock
 fudge 127.127.1.0 stratum 10
-<% end -%>
 
+<% end -%>
 <%
   t_servers = []
   if @servers.kind_of?(Array)
-    t_servers = @servers.map{|x| "server #{x}"}
+    options = @default_options.empty? ? '' : " #{Array(@default_options).join(' ')}"
+    t_servers = @servers.map{|x| "server #{x}#{options}"}
   else
     @servers.keys.sort.each do |ntp_server|
       if @servers[ntp_server] and !@servers[ntp_server].empty?
@@ -34,7 +38,6 @@ fudge 127.127.1.0 stratum 10
     end
   end
 -%>
-
 <%= t_servers.join("\n") %>
 driftfile /var/lib/ntp/drift
 broadcastdelay  <%= @broadcastdelay %>


### PR DESCRIPTION
- Fixed bug in which ntpd::ntpd_options was not applied to
  ntpd::servers when ntpd::servers is an array.
- Reverted incorrect version bump, as interim version has
  not been released

SIMP-4943 #close