### PR TITLE
(SIMP-6114) Use namespaced simplib::nets2ddq

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1-0
+- Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq
+
 * Wed Mar 06 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0-0
 - Validated Puppet 6 support
 - Ensure that users can change the default 'restrict' parameters

--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -20,7 +20,7 @@ define ntpd::allow (
 ) {
   include 'ntpd'
 
-  $l_trusted_nets = nets2ddq($trusted_nets)
+  $l_trusted_nets = simplib::nets2ddq($trusted_nets)
 
   concat::fragment { "ntpd_${name}.allow":
     order   => 100,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ntpd",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "manages NTP server and client",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.8.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq

SIMP-6114 #comment pupmod-simp-ntpd